### PR TITLE
feat(add with Alias): support add using alias command

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,30 @@ yarn.optionalDependencies('isobject', function(err) {
 
 </details>
 
+<details>
+<summary><strong>.addWithAlias</strong></summary>
+
+### [.addWithAlias](index.js#L117)
+
+Execute `yarn add fake-name@module-name`. Install the module with a fake-name called alias.
+run require('fake-name') to use the module
+It's Yarn tip
+
+**Params**
+
+* `name` **{String}**: One package name to install
+* `alias` **{String}**: package alias to use
+* `cb` **{Function}**: Callback
+
+**Example**
+
+```js
+yarn.addWithAlias('isobject','fake-name', function(err) {
+  if (err) throw err;
+});
+```
+
+</details>
 ## About
 
 ### Contributing

--- a/examples/addWithAlias.js
+++ b/examples/addWithAlias.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var yarn = require('..');
+
+yarn.addWithAlias('lodash', '_', function(err) {
+  if (err) return console.error(err);
+  console.log('done');
+});

--- a/index.js
+++ b/index.js
@@ -36,12 +36,12 @@ function yarn(cmds, args, cb) {
   }
 
   args = arrayify(cmds).concat(arrayify(args));
-  spawn('yarn', args, {cwd: cwd, stdio: 'inherit'})
+  spawn('yarn', args, { cwd: cwd, stdio: 'inherit' })
     .on('error', cb)
     .on('close', function(code, err) {
       cb(err, code);
     });
-};
+}
 
 /**
  * Symlink the current project to global `node_modules`.
@@ -94,6 +94,28 @@ yarn.unlink = function(args, cb) {
 
 yarn.add = function(args, cb) {
   yarn('add', args, cb);
+};
+
+/**
+ * Installs one package with alias.
+ * You can alias a package by using `yarn add fake-name@npm:left-pad`.
+ * Now you can use `require("fake-name")` to require left-pad.
+ *
+ * Visit the yarn docs for [add][cli]{add}.
+ *
+ * ```js
+ * yarn.add('isobject', 'myAlias', function(err) {
+ *   if (err) throw err;
+ * });
+ * ```
+ * @param {String} `name` package name
+ * @param {String} `alias` package alias
+ * @param {Function} `cb` Callback
+ * @api public
+ */
+
+yarn.addWithAlias = function(name, alias, cb) {
+  yarn('add', [alias, '@npm:', args], cb);
 };
 
 /**

--- a/test/test.js
+++ b/test/test.js
@@ -11,6 +11,7 @@ describe('yarn', function() {
 
   it('should expose methods', function() {
     assert.equal(typeof yarn.add, 'function');
+    assert.equal(typeof yarn.addWithAlias, 'function');
     assert.equal(typeof yarn.dependencies, 'function');
     assert.equal(typeof yarn.devDependencies, 'function');
     assert.equal(typeof yarn.global, 'function');


### PR DESCRIPTION
One of the most useful tip that yarn provide is installing dependency with alias

it works well with node_modules.

Developer can use it to install two version of the same module and differenciate with the alias.

Example:
yarn add lodash-2@npm:lodash@2.0.0
yarn add lodash-3@npm:lodash@3.0.0
let _2 = require(lodash-2)
let _3 = require(lodash-3)
Two version installed in the same runtime.

It's useful when upgrading large project modules so in some cases we need more than running version of the same module
Official docs: https://yarnpkg.com/lang/en/docs/cli/add/#toc-yarn-add-alias